### PR TITLE
Removed reference to leselys.config in the script

### DIFF
--- a/scripts/leselys
+++ b/scripts/leselys
@@ -9,7 +9,6 @@ from docopt import docopt
 from leselys import core
 from leselys import accounts
 
-from leselys.config import get_config
 from leselys.backends import _load_backend
 
 doc = """Leselys is a Web Interface for Leselys.


### PR DESCRIPTION
If you make a clean checkout, the script doesn't work as it has an unused and undefined reference to leselys.config.(something). This just removes that.
