### PR TITLE
add cancel button and escape key binding for add feed popover

### DIFF
--- a/leselys/static/css/leselys.css
+++ b/leselys/static/css/leselys.css
@@ -172,7 +172,7 @@ li a [class^="icon-"] {
 }
 
 #add button {
-  display: block;
+  margin: 0.125em;
 }
 
 #add form {

--- a/leselys/static/js/leselys.js
+++ b/leselys/static/js/leselys.js
@@ -39,8 +39,7 @@ function addFeed() {
   if (url == '') { return false }
 
   // Undisplay add popup
-  document.getElementById('add').style.display = "none";
-  document.getElementById('urlFeed').value = "";
+  addToggle();
 
   // Clear help message if no subscriptions
   if (document.getElementById('menu').getElementsByClassName('empty-feed-list')) {
@@ -762,12 +761,19 @@ function addEventListenerList(list, event, fn) {
 
 function addToggle() {
   var add = document.getElementById('add');
+  Mousetrap.reset();
+
   if (add.style.display == "block" ) {
+    // hide the popover and reset state
     add.style.display = "none";
-  } else {
-    add.style.display = "block";
+    setKeyboard();
+    return;
   }
+
+  // show the popover and set state
+  add.style.display = "block";
   document.getElementById('urlFeed').focus();
+  Mousetrap.bind('esc', function(e, combo) { addToggle(); });
 }
 
 function cleanCounter(counter) {

--- a/leselys/templates/home.html
+++ b/leselys/templates/home.html
@@ -11,10 +11,10 @@
   </div>
   <div id="content" class="span10">
     <div class="hero-unit welcome">
-    	<h1>Hi,</h1>
-	      <p>I'm Leselys, your very elegant RSS reader.</p>
-      	<p><a href="https://github.com/socketubs/leselys" target="_blank" class="btn btn-primary btn-large">
-			Learn more</a></p>
+      <h1>Hi,</h1>
+        <p>I'm Leselys, your very elegant RSS reader.</p>
+        <p><a href="https://github.com/socketubs/leselys" target="_blank" class="btn btn-primary btn-large">
+      Learn more</a></p>
     </div>
   </div>
 </div>
@@ -34,11 +34,17 @@
                 crel('center',
                     crel('input', {'id': 'urlFeed',
                                    'type': 'text',
-                                   'class': 'input-large',
+                                   'class': 'input-large mousetrap',
                                    'placeholder': 'Url...'}),
-                    crel('button', {'type': 'submit',
-                                    'class': 'btn',
-                                    'onclick': 'addFeed()'}, 'Submit')
+                    crel('div',
+                        crel('button', {'type': 'reset',
+                                        'class': 'btn',
+                                        'onclick': 'addToggle()'},
+                             'Cancel'),
+                        crel('button', {'type': 'submit',
+                                        'class': 'btn',
+                                        'onclick': 'addFeed()'},
+                             'Submit'))
                 )
             )
         ))

--- a/leselys/templates/settings.html
+++ b/leselys/templates/settings.html
@@ -41,7 +41,7 @@
           <hr>
           <div id="password-form" class="control-group">
             <h3>Password</h3>
-            
+
             <input id="password1" type="password" placeholder="Type your new password…">
             <input id="password2" type="password" placeholder="Type it again…">
             <div id="password-status"></div><br /><br />
@@ -68,7 +68,7 @@
               <div style="position:relative;">
                 <button type="submit" class="btn btn-info">Download</button>
               </div>
-          </form> 
+          </form>
         </div>
         <div class="tab-pane" id="help">
           <h3>Keyboard</h3>
@@ -76,7 +76,7 @@
             <li><code>g then h</code> Go to Home view</li>
             <li><code>?</code> Show this help</li>
             <li><code>r</code> Refresh feeds list</li>
-            <li><code>a</code> Add feed popup</li>
+            <li><code>a</code> Add feed popup (ESC to cancel)</li>
             <li><code>m</code> Toggle read/unread state of selected story</li>
             <li><code>o</code> Toggle open/close selected story</li>
             <li><code>j</code> Select and open next story</li>


### PR DESCRIPTION
The add feed popover had no convenient way to cancel. This patch adds a cancel button, plus a keyboard shortcut using the escape key. Because the key binding has to work inside the form text input, that text input has the `mousetrap` class. All other key bindings are unbound when the popover is visible, then rebound when it closes.

Note that I am not in a position to minify the JS or CSS, so I did not check in updates to those files.
