### PR TITLE
reverse proxy support

### DIFF
--- a/leselys/core.py
+++ b/leselys/core.py
@@ -16,6 +16,39 @@ from werkzeug.contrib.cache import SimpleCache
 from leselys.backends.storage import _load_storage
 from leselys.backends.session import _load_session
 
+# from http://flask.pocoo.org/snippets/35/
+class ReverseProxied(object):
+    '''Wrap the application in this middleware and configure the
+    front-end server to add these headers, to let you quietly bind
+    this to a URL other than / and to an HTTP scheme that is
+    different than what is used locally.
+
+    In nginx:
+    location /myprefix {
+        proxy_pass http://192.168.0.1:5001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Script-Name /myprefix;
+        }
+
+    :param app: the WSGI application
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        script_name = environ.get('HTTP_X_SCRIPT_NAME', '')
+        if script_name:
+            environ['SCRIPT_NAME'] = script_name
+            path_info = environ['PATH_INFO']
+            if path_info.startswith(script_name):
+                environ['PATH_INFO'] = path_info[len(script_name):]
+
+        scheme = environ.get('HTTP_X_SCHEME', '')
+        if scheme:
+            environ['wsgi.url_scheme'] = scheme
+        return self.app(environ, start_response)
 
 class Core(object):
     def __init__(self):
@@ -30,6 +63,7 @@ class Core(object):
         self.app = Flask(__name__)
         self.app.config['SECRET_KEY'] = os.urandom(24)
         self.app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 31536000
+        self.app.wsgi_app = ReverseProxied(self.app.wsgi_app)
 
         py_v = sys.version_info
         py_v = "%s.%s.%s" % (py_v[0], py_v[1], py_v[2])

--- a/leselys/static/js/ajax.js
+++ b/leselys/static/js/ajax.js
@@ -33,7 +33,7 @@ function sendFile(options){
 
         // Try parsing to JSON
         try { data = JSON.parse(data); } catch(e) {
-          window.location = "/";
+          window.location = "";
         };
 
         if (options['callback'])
@@ -82,7 +82,7 @@ function ajaxRequest(options){
 
         // Try parsing to JSON
         try { data = JSON.parse(data); } catch(e) {
-          window.location = "/";
+          window.location = "";
         };
 
         if (options['callback'])

--- a/leselys/static/js/api.js
+++ b/leselys/static/js/api.js
@@ -2,7 +2,7 @@ api = {};
 
 api.changePassword = function(password, callback) {
     return ajaxRequest({
-        url: '/api/set_password',
+        url: 'api/set_password',
         method: 'POST',
         params: {
             password: password
@@ -13,7 +13,7 @@ api.changePassword = function(password, callback) {
 
 api.addFeed = function(feedUrl, callback) {
     return ajaxRequest({
-        url: '/api/add',
+        url: 'api/add',
         method: 'POST',
         params: {
             url: feedUrl
@@ -24,7 +24,7 @@ api.addFeed = function(feedUrl, callback) {
 
 api.deleteFeed = function(feedId, callback) {
     return ajaxRequest({
-        url: '/api/remove/' + feedId,
+        url: 'api/remove/' + feedId,
         method: 'DELETE',
         callback : callback
     });
@@ -32,7 +32,7 @@ api.deleteFeed = function(feedId, callback) {
 
 api.setFeedSetting = function(feedId, settingKey, settingValue, callback) {
     return ajaxRequest({
-        url: '/api/feedsettings',
+        url: 'api/feedsettings',
         method: 'POST',
         params: {
             feed_id: feedId,
@@ -45,7 +45,7 @@ api.setFeedSetting = function(feedId, settingKey, settingValue, callback) {
 
 api.importOPML = function(file, callback) {
     return sendFile({
-        url: '/api/import/opml',
+        url: 'api/import/opml',
         params: {
             fileInput: file
         },
@@ -55,7 +55,7 @@ api.importOPML = function(file, callback) {
 
 api.getSettings = function(callback) {
     return ajaxRequest({
-        url: '/settings',
+        url: 'settings',
         method: 'GET',
         params: {
             jsonify: true
@@ -66,7 +66,7 @@ api.getSettings = function(callback) {
 
 api.getHome = function(callback) {
     return ajaxRequest({
-        url: '/',
+        url: '.',
         method: 'GET',
         params: {
             jsonify: true
@@ -79,7 +79,7 @@ api.getFeed = function(feedId, start, stop, callback) {
     var start = start || 0;
     var stop = stop || 50;
     return ajaxRequest({
-        url: '/api/get/' + feedId,
+        url: 'api/get/' + feedId,
         params: {
             start: start,
             stop: stop
@@ -91,7 +91,7 @@ api.getFeed = function(feedId, start, stop, callback) {
 
 api.readStory = function(storyId, callback) {
     return ajaxRequest({
-        url: '/api/read/' + storyId,
+        url: 'api/read/' + storyId,
         method: 'GET',
         callback: callback
     });
@@ -99,7 +99,7 @@ api.readStory = function(storyId, callback) {
 
 api.unreadStory = function(storyId, callback) {
     return ajaxRequest({
-        url: '/api/unread/' + storyId,
+        url: 'api/unread/' + storyId,
         method: 'GET',
         callback: callback
     });
@@ -118,7 +118,7 @@ api.setTheme = function(themeName, callback) {
 
 api.getCounters = function(callback) {
     return ajaxRequest({
-        url: '/api/counters',
+        url: 'api/counters',
         method: 'GET',
         callback: callback
     });
@@ -126,7 +126,7 @@ api.getCounters = function(callback) {
 
 api.markAllAsRead = function(feedId, callback) {
     return ajaxRequest({
-        url: '/api/all_read/' + feedId,
+        url: 'api/all_read/' + feedId,
         method: 'GET',
         callback: callback
     });
@@ -134,7 +134,7 @@ api.markAllAsRead = function(feedId, callback) {
 
 api.markAllAsUnread = function(feedId, callback) {
     return ajaxRequest({
-        url: '/api/all_unread/' + feedId,
+        url: 'api/all_unread/' + feedId,
         method: 'GET',
         callback: callback
     });

--- a/leselys/static/js/leselys.js
+++ b/leselys/static/js/leselys.js
@@ -88,7 +88,7 @@ function addFeed() {
         newFeedSetting.style.display = "";
       }
     } else {
-      if (data.callback == "/api/login") { window.location = "/login" }
+      if (data.callback == "/api/login") { window.location = "login" }
       loader.innerHTML = '<li><i class="icon-exclamation-sign"></i> Error: ' + data.output +'</li>';
       var clearLoader = function() {
         loader.style.display = "none";
@@ -136,7 +136,7 @@ function handleOPMLImport(evt) {
           document.getElementById("OPMLSubmit").className += " disabled";
         } else {
           if (data.callback == "/api/login")
-            window.location = "/login"
+            window.location = "login"
           document.getElementById("OPMLSubmit").innerHTML = "Error: " + data.output;
           document.getElementById("OPMLSubmit").className += " disabled";
         }
@@ -173,7 +173,7 @@ function viewSettings(callback) {
       disableRibbon();
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }
@@ -195,7 +195,7 @@ function viewHome(callback) {
       }
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }
@@ -230,7 +230,7 @@ function deleteFeed(feedId) {
       }
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }
@@ -326,7 +326,7 @@ function viewFeed(feedId, callback) {
       });
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }
@@ -375,7 +375,7 @@ function readStory(storyId, ignore) {
   api.readStory(storyId, function(req, data) {
     if (!data.success) {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
     if (data.content.last_update == false) {
       var published = "No date";
@@ -444,14 +444,14 @@ function unreadStory(storyId) {
       document.getElementById(storyId).getElementsByClassName("accordion-toggle")[0].style.fontWeight = 'bold';
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }
 
 function loadTheme(themeName, callback) {
   api.setTheme(themeName, function(req, data) {
-    window.location = "/";
+    window.location = "";
   });
 }
 
@@ -473,7 +473,7 @@ function refreshCounters() {
       }
     } else {
       if (data.callback == "/api/login")
-        window.location = "/login"
+        window.location = "login"
     }
   });
 }

--- a/leselys/templates/login.html
+++ b/leselys/templates/login.html
@@ -51,7 +51,7 @@
   <div class="jumbotron">
     <h1>Welcome back.</h1>
     <div class="setup">
-      <form id="welcome-form" method="POST" action="/api/login?jsonify=false">
+      <form id="welcome-form" method="POST" action="api/login?jsonify=false">
         <div class="control-group">
           <input style="width: 210px" name="password" id="password" type="password" autofocus="autofocus"/ >
           <i class="icon-lock field-icon"></i>

--- a/leselys/templates/settings.html
+++ b/leselys/templates/settings.html
@@ -63,7 +63,7 @@
               </div>
           </div>
           <hr>
-          <form class="form-inline" method="GET" action="/api/export/opml">
+          <form class="form-inline" method="GET" action="api/export/opml">
             <h3>Export</h3>
               <div style="position:relative;">
                 <button type="submit" class="btn btn-info">Download</button>

--- a/leselys/templates/sidebar.html
+++ b/leselys/templates/sidebar.html
@@ -6,7 +6,7 @@
         <a title="Home" href="#" onclick="viewHome()"><i class="icon-home"></i></a>
         <a title="Settings" href="#" onclick="viewSettings()"><i class="icon-wrench"></i></a>
         <a title="Add subscription" href="#" onclick="addToggle()"><i class="icon-plus-sign"></i></a>
-        <a title="Logout" href="/logout"><i class="icon-off"></i></a>
+        <a title="Logout" href="logout"><i class="icon-off"></i></a>
       </li>
     </center>
     <li class="divider"></li>

--- a/leselys/templates/welcome.html
+++ b/leselys/templates/welcome.html
@@ -52,7 +52,7 @@
     <h1>Welcome on your Leselys!</h1>
     <p class="lead">You just have to set a password to start using it. After that, you can import your Google Reader or any other OPML file.</p>
     <div class="setup">
-      <form id="welcome-form" method="POST" action="/api/set_password?jsonify=false" >
+      <form id="welcome-form" method="POST" action="api/set_password?jsonify=false" >
         <div class="control-group">
           <input style="width: 210px" name="password" id="password" type="password" autofocus="autofocus"/ >
           <i class="icon-lock field-icon"></i>


### PR DESCRIPTION
The basic idea is to make sure that leselys will work as a standalone server or behind a reverse proxy, including when configured with a URL prefix like `/leselys/`. This involved wrapping `wsgi_app` in a small custom class to rewrite path info, and modifying quite a bit of javascript and template code to use relative paths instead of rooted paths.

I've done a fair amount of testing, and I think everything still works for standalone servers too. But if you find any problems, just let me know.

Sample nginx config:

```
    # reverse-proxy for leselys
    rewrite ^/leselys$ /leselys/ permanent;
    location /leselys {
            rewrite ^/leselys(/?.*)$ $1 break;
            proxy_pass     http://127.0.0.1:5000;
            proxy_redirect off;
            proxy_set_header   Host             $host;
            proxy_set_header   X-Real-IP        $remote_addr;
            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
            proxy_set_header   X-Scheme $scheme;
            proxy_set_header X-Script-Name /leselys;
    }
```
