### PR TITLE
when using keyboard navigation, make sure the current story is visible

### DIFF
--- a/leselys/static/js/leselys.js
+++ b/leselys/static/js/leselys.js
@@ -755,13 +755,15 @@ function setKeyboard(){
    });
    Mousetrap.bind('j', function() {
      var nextStory = getNextStory();
-     if (nextStory == false) { return }
+     if (nextStory == false) { return; }
      nextStory.getElementsByTagName('a')[0].click();
+     nextStory.scrollIntoView();
    });
    Mousetrap.bind('k', function() {
      var previousStory = getPreviousStory();
-     if (previousStory == false) { return }
+     if (previousStory == false) { return; }
      previousStory.getElementsByTagName('a')[0].click();
+     previousStory.scrollIntoView();
    });
 }
 


### PR DESCRIPTION
With firefox 21.0 and long stories, I noticed scrolling down, then hitting 'j' for the next story caused problems. It would often leave the next story open, but outside the current viewport. This patch adds a call to `scrollIntoView` after the simulated clicks for next and previous story, which seems to fix the problem.
